### PR TITLE
Fix/fix navigation issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "fmt.check": "prettier --check .",
     "lint": "eslint \"src/**/*.ts*\"",
     "preview": "qwik build preview && vite preview --open --host",
+    "serve": "python3 -m http.server 8080 --bind 127.0.0.1 --directory dist",
     "start": "vite --open --mode ssr",
     "test": "vitest",
     "qwik": "qwik"

--- a/src/routes/tv/[api]/index.tsx
+++ b/src/routes/tv/[api]/index.tsx
@@ -24,9 +24,9 @@ export const head: DocumentHead = {
 };
 
 export default component$(() => {
-  const { url, params } = useLocation();
+  const { params, url } = useLocation();
   const { api } = params;
-  const { searchParams } = url;
+  const { search } = url;
   const id = useSignal<ReturnType<URLSearchParams['get']>>(null);
   const navigate = useNavigate();
   const app = useAppState();
@@ -43,17 +43,26 @@ export default component$(() => {
 
   useVisibleTask$(async ({ track }) => {
     track(() => api);
-    track(() => searchParams);
+    track(() => search);
 
     if (!(api in TvApi)) {
-      navigate(new URL('/rategrid/tv', url).toString(), { replaceState: true });
+      navigate('/rategrid/tv/', { replaceState: true });
       tvApiData.value = null;
     }
 
-    id.value = searchParams.get('id');
+    // For whatever reason, the useLocation hook does not return the correct search params on page load.
+    const url = new URL(window.location.href);
+
+    id.value = url.searchParams.get('id');
     isPendingId.value = false;
 
     if (id.value === null) {
+      return;
+    }
+
+    if (id.value.length === 0) {
+      navigate(`/rategrid/tv/${api}/`, { replaceState: true });
+      id.value = null;
       return;
     }
 
@@ -153,7 +162,7 @@ export default component$(() => {
               ) : (
                 <Section>
                   <p>
-                    You might know <span class="bg-paper-9">{id.value}</span>, but i haven't heard of it :&#40;
+                    You might know <span class="bg-paper-9 px-2">{id.value}</span>, but i haven't heard of it :&#40;
                   </p>
                 </Section>
               )

--- a/src/routes/tv/index.tsx
+++ b/src/routes/tv/index.tsx
@@ -1,19 +1,16 @@
 import { component$, useVisibleTask$ } from '@builder.io/qwik';
-import { useLocation, useNavigate } from '@builder.io/qwik-city';
+import { useNavigate } from '@builder.io/qwik-city';
 
 import { TvApiDefault } from '~/constants';
-import { withTrailingSlash } from '~/utils/url';
 
 /**
  * Redirect to the use the default API.
  */
 export default component$(() => {
-  const { url } = useLocation();
   const navigate = useNavigate();
 
   useVisibleTask$(() => {
-    url.pathname = withTrailingSlash(url.pathname);
-    navigate(new URL(TvApiDefault, url).toString(), { replaceState: true });
+    navigate(`/rategrid/tv/${TvApiDefault}/`, { replaceState: true });
   });
 
   return <></>;

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { withTrailingSlash } from './url';
+import { hasTrailingQuestionMark, withTrailingSlash } from './url';
 
 describe('url utilities', async () => {
   test('withTrailingSlash', async () => {
@@ -10,5 +10,18 @@ describe('url utilities', async () => {
     expect(withTrailingSlash('hi/there/')).toBe('hi/there/');
     expect(withTrailingSlash('hi/there/123')).toBe('hi/there/123/');
     expect(withTrailingSlash('hi/there/123/')).toBe('hi/there/123/');
+  });
+
+  test('hasTrailingQuestionMark', async () => {
+    expect(hasTrailingQuestionMark('hi')).toBe(false);
+    expect(hasTrailingQuestionMark('hi?')).toBe(true);
+    expect(hasTrailingQuestionMark('hi/there')).toBe(false);
+    expect(hasTrailingQuestionMark('hi/there?')).toBe(true);
+    expect(hasTrailingQuestionMark('hi/there/?')).toBe(true);
+    expect(hasTrailingQuestionMark('?hi/there/')).toBe(false);
+    expect(hasTrailingQuestionMark('?hi/there/?')).toBe(true);
+    expect(hasTrailingQuestionMark('hi/there/?/')).toBe(false);
+    expect(hasTrailingQuestionMark('hi/there/?id=')).toBe(false);
+    expect(hasTrailingQuestionMark('hi/there/?id=123')).toBe(false);
   });
 });

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,9 @@
 type EnsureTrailingSlash<T extends string> = T extends `${infer P}/` ? `${P}/` : `${T}/`;
 
+export const hasTrailingQuestionMark = <T extends string>(path: T): boolean => {
+  return /\?$/.test(path);
+};
+
 export const withTrailingSlash = <T extends string>(path: T): EnsureTrailingSlash<T> => {
   return /\/$/.test(path) ? (path as unknown as EnsureTrailingSlash<T>) : (`${path}/` as EnsureTrailingSlash<T>);
 };


### PR DESCRIPTION
fix navigation issues - was causes by Qwik useNavigate() hook searchParams being out of sync on page load.

add serve script.